### PR TITLE
334340043: Deprecated CopyFromString in favor of CopyFromDatetimeString #73

### DIFF
--- a/dfdatetime/cocoa_time.py
+++ b/dfdatetime/cocoa_time.py
@@ -37,7 +37,7 @@ class CocoaTime(interface.DateTimeValues):
     self.precision = definitions.PRECISION_1_SECOND
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a Cocoa timestamp from a date and time string.
 
     Args:

--- a/dfdatetime/decorators.py
+++ b/dfdatetime/decorators.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""Function decorators."""
+
+from __future__ import unicode_literals
+
+import warnings
+
+
+def deprecated(function):
+  """Decorator to mark functions or methods as deprecated."""
+
+  def IssueDeprecationWarning(*args, **kwargs):
+    """Issue a deprecation warning."""
+    warnings.simplefilter('always', DeprecationWarning)
+    warnings.warn('Call to deprecated function: {0:s}.'.format(
+        function.__name__), category=DeprecationWarning, stacklevel=2)
+    warnings.simplefilter('default', DeprecationWarning)
+
+    return function(*args, **kwargs)
+
+  IssueDeprecationWarning.__name__ = function.__name__
+  IssueDeprecationWarning.__doc__ = function.__doc__
+  IssueDeprecationWarning.__dict__.update(function.__dict__)
+  return IssueDeprecationWarning

--- a/dfdatetime/delphi_date_time.py
+++ b/dfdatetime/delphi_date_time.py
@@ -45,7 +45,7 @@ class DelphiDateTime(interface.DateTimeValues):
     self.precision = definitions.PRECISION_1_MILLISECOND
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a Delphi TDateTime timestamp from a string.
 
     Args:

--- a/dfdatetime/fake_time.py
+++ b/dfdatetime/fake_time.py
@@ -30,7 +30,7 @@ class FakeTime(interface.DateTimeValues):
     self._number_of_seconds = int(timestamp)
     self.precision = definitions.PRECISION_1_MICROSECOND
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a fake timestamp from a date and time string.
 
     Args:

--- a/dfdatetime/fat_date_time.py
+++ b/dfdatetime/fat_date_time.py
@@ -93,7 +93,7 @@ class FATDateTime(interface.DateTimeValues):
     number_of_seconds += number_of_days * self._SECONDS_PER_DAY
     return number_of_seconds
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a FAT date time from a date and time string.
 
     Args:

--- a/dfdatetime/filetime.py
+++ b/dfdatetime/filetime.py
@@ -37,7 +37,7 @@ class Filetime(interface.DateTimeValues):
     self.precision = definitions.PRECISION_100_NANOSECONDS
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a FILETIME timestamp from a date and time string.
 
     Args:

--- a/dfdatetime/hfs_time.py
+++ b/dfdatetime/hfs_time.py
@@ -34,7 +34,7 @@ class HFSTime(interface.DateTimeValues):
     self.precision = definitions.PRECISION_1_SECOND
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a HFS timestamp from a date and time string.
 
     Args:

--- a/dfdatetime/interface.py
+++ b/dfdatetime/interface.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 import abc
 import calendar
 
+from dfdatetime import decorators
+
 
 class DateTimeValues(object):
   """Defines the date time values interface.
@@ -569,8 +571,26 @@ class DateTimeValues(object):
     # pylint: disable=consider-using-ternary
     return (year % 4 == 0 and year % 100 != 0) or year % 400 == 0
 
-  @abc.abstractmethod
+  @decorators.deprecated
   def CopyFromString(self, time_string):
+    """Copies a date time value from a date and time string.
+
+    Args:
+      time_string (str): date and time value formatted as:
+          YYYY-MM-DD hh:mm:ss.######[+-]##:##
+
+          Where # are numeric digits ranging from 0 to 9 and the seconds
+          fraction can be either 3 or 6 digits. The time of day, seconds
+          fraction and time zone offset are optional. The default time zone
+          is UTC.
+
+    Raises:
+      ValueError: if the time string is invalid or not supported.
+    """
+    self.CopyFromDateTimeString(time_string)
+
+  @abc.abstractmethod
+  def CopyFromDateTimeString(self, time_string):
     """Copies a date time value from a date and time string.
 
     Args:

--- a/dfdatetime/java_time.py
+++ b/dfdatetime/java_time.py
@@ -36,7 +36,7 @@ class JavaTime(interface.DateTimeValues):
     self.precision = definitions.PRECISION_1_MILLISECOND
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a Java timestamp from a date and time string.
 
     Args:

--- a/dfdatetime/posix_time.py
+++ b/dfdatetime/posix_time.py
@@ -34,7 +34,7 @@ class PosixTime(interface.DateTimeValues):
     self.precision = definitions.PRECISION_1_SECOND
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a POSIX timestamp from a date and time string.
 
     Args:
@@ -125,7 +125,7 @@ class PosixTimeInMicroseconds(interface.DateTimeValues):
     self.precision = definitions.PRECISION_1_MICROSECOND
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a POSIX timestamp from a date and time string.
 
     Args:

--- a/dfdatetime/rfc2579_date_time.py
+++ b/dfdatetime/rfc2579_date_time.py
@@ -122,7 +122,7 @@ class RFC2579DateTime(interface.DateTimeValues):
           self.year, self.month, self.day_of_month, self.hours, self.minutes,
           self.seconds)
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a RFC2579 date-time from a date and time string.
 
     Args:

--- a/dfdatetime/semantic_time.py
+++ b/dfdatetime/semantic_time.py
@@ -42,6 +42,14 @@ class SemanticTime(interface.DateTimeValues):
     """
     self.string = time_string
 
+  def CopyToDateTimeString(self):
+    """Copies the date time value to a date and time string.
+
+    Returns:
+      str: semantic representation of the time, such as: "Never", "Not set".
+    """
+    return self.string
+
   def CopyToStatTimeTuple(self):
     """Copies the semantic timestamp to a stat timestamp tuple.
 

--- a/dfdatetime/semantic_time.py
+++ b/dfdatetime/semantic_time.py
@@ -30,7 +30,7 @@ class SemanticTime(interface.DateTimeValues):
     super(SemanticTime, self).__init__()
     self.string = string
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies semantic time from a date and time string.
 
     Args:

--- a/dfdatetime/systemtime.py
+++ b/dfdatetime/systemtime.py
@@ -102,7 +102,7 @@ class Systemtime(interface.DateTimeValues):
           self.year, self.month, self.day_of_month, self.hours, self.minutes,
           self.seconds)
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a SYSTEMTIME structure from a date and time string.
 
     Args:

--- a/dfdatetime/time_elements.py
+++ b/dfdatetime/time_elements.py
@@ -316,7 +316,7 @@ class TimeElements(interface.DateTimeValues):
 
     self._CopyFromDateTimeValues(date_time_values)
 
-  def CopyFromDateTimeStringTuple(self, time_elements_tuple):
+  def CopyFromStringTuple(self, time_elements_tuple):
     """Copies time elements from string-based time elements tuple.
 
     Args:
@@ -468,7 +468,7 @@ class TimeElementsInMilliseconds(TimeElements):
 
     self.is_local_time = False
 
-  def CopyFromDateTimeStringTuple(self, time_elements_tuple):
+  def CopyFromStringTuple(self, time_elements_tuple):
     """Copies time elements from string-based time elements tuple.
 
     Args:
@@ -482,7 +482,7 @@ class TimeElementsInMilliseconds(TimeElements):
     if len(time_elements_tuple) < 7:
       raise ValueError('Invalid time elements tuple 7 elements required.')
 
-    super(TimeElementsInMilliseconds, self).CopyFromDateTimeStringTuple(
+    super(TimeElementsInMilliseconds, self).CopyFromStringTuple(
         time_elements_tuple)
     try:
       self._milliseconds = int(time_elements_tuple[6], 10)
@@ -589,7 +589,7 @@ class TimeElementsInMicroseconds(TimeElements):
 
     self.is_local_time = False
 
-  def CopyFromDateTimeStringTuple(self, time_elements_tuple):
+  def CopyFromStringTuple(self, time_elements_tuple):
     """Copies time elements from string-based time elements tuple.
 
     Args:
@@ -603,7 +603,7 @@ class TimeElementsInMicroseconds(TimeElements):
     if len(time_elements_tuple) < 7:
       raise ValueError('Invalid time elements tuple 7 elements required.')
 
-    super(TimeElementsInMicroseconds, self).CopyFromDateTimeStringTuple(
+    super(TimeElementsInMicroseconds, self).CopyFromStringTuple(
         time_elements_tuple)
     try:
       self._microseconds = int(time_elements_tuple[6], 10)

--- a/dfdatetime/time_elements.py
+++ b/dfdatetime/time_elements.py
@@ -274,7 +274,7 @@ class TimeElements(interface.DateTimeValues):
 
     return hours, minutes, seconds, microseconds, time_zone_offset
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies time elements from a date and time string.
 
     Args:
@@ -290,7 +290,7 @@ class TimeElements(interface.DateTimeValues):
 
     self._CopyFromDateTimeValues(date_time_values)
 
-  def CopyFromStringISO8601(self, time_string):
+  def CopyFromDateTimeStringISO8601(self, time_string):
     """Copies time elements from an ISO 8601 date and time string.
 
     Currently not supported:
@@ -316,7 +316,7 @@ class TimeElements(interface.DateTimeValues):
 
     self._CopyFromDateTimeValues(date_time_values)
 
-  def CopyFromStringTuple(self, time_elements_tuple):
+  def CopyFromDateTimeStringTuple(self, time_elements_tuple):
     """Copies time elements from string-based time elements tuple.
 
     Args:
@@ -468,7 +468,7 @@ class TimeElementsInMilliseconds(TimeElements):
 
     self.is_local_time = False
 
-  def CopyFromStringTuple(self, time_elements_tuple):
+  def CopyFromDateTimeStringTuple(self, time_elements_tuple):
     """Copies time elements from string-based time elements tuple.
 
     Args:
@@ -482,7 +482,7 @@ class TimeElementsInMilliseconds(TimeElements):
     if len(time_elements_tuple) < 7:
       raise ValueError('Invalid time elements tuple 7 elements required.')
 
-    super(TimeElementsInMilliseconds, self).CopyFromStringTuple(
+    super(TimeElementsInMilliseconds, self).CopyFromDateTimeStringTuple(
         time_elements_tuple)
     try:
       self._milliseconds = int(time_elements_tuple[6], 10)
@@ -589,7 +589,7 @@ class TimeElementsInMicroseconds(TimeElements):
 
     self.is_local_time = False
 
-  def CopyFromStringTuple(self, time_elements_tuple):
+  def CopyFromDateTimeStringTuple(self, time_elements_tuple):
     """Copies time elements from string-based time elements tuple.
 
     Args:
@@ -603,7 +603,7 @@ class TimeElementsInMicroseconds(TimeElements):
     if len(time_elements_tuple) < 7:
       raise ValueError('Invalid time elements tuple 7 elements required.')
 
-    super(TimeElementsInMicroseconds, self).CopyFromStringTuple(
+    super(TimeElementsInMicroseconds, self).CopyFromDateTimeStringTuple(
         time_elements_tuple)
     try:
       self._microseconds = int(time_elements_tuple[6], 10)

--- a/dfdatetime/time_elements.py
+++ b/dfdatetime/time_elements.py
@@ -290,7 +290,7 @@ class TimeElements(interface.DateTimeValues):
 
     self._CopyFromDateTimeValues(date_time_values)
 
-  def CopyFromDateTimeStringISO8601(self, time_string):
+  def CopyFromStringISO8601(self, time_string):
     """Copies time elements from an ISO 8601 date and time string.
 
     Currently not supported:

--- a/dfdatetime/uuid_time.py
+++ b/dfdatetime/uuid_time.py
@@ -42,7 +42,7 @@ class UUIDTime(interface.DateTimeValues):
     self.precision = definitions.PRECISION_100_NANOSECONDS
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies an UUID timestamp from a date and time string.
 
     Args:

--- a/dfdatetime/webkit_time.py
+++ b/dfdatetime/webkit_time.py
@@ -34,7 +34,7 @@ class WebKitTime(interface.DateTimeValues):
     self.precision = definitions.PRECISION_1_MICROSECOND
     self.timestamp = timestamp
 
-  def CopyFromString(self, time_string):
+  def CopyFromDateTimeString(self, time_string):
     """Copies a WebKit timestamp from a date and time string.
 
     Args:

--- a/tests/cocoa_time.py
+++ b/tests/cocoa_time.py
@@ -12,32 +12,32 @@ from dfdatetime import cocoa_time
 class CocoaTimeTest(unittest.TestCase):
   """Tests for the Cocoa timestamp."""
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     cocoa_time_object = cocoa_time.CocoaTime()
 
     expected_timestamp = 394934400.0
-    cocoa_time_object.CopyFromString('2013-07-08')
+    cocoa_time_object.CopyFromDateTimeString('2013-07-08')
     self.assertEqual(cocoa_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 395011845.0
-    cocoa_time_object.CopyFromString('2013-07-08 21:30:45')
+    cocoa_time_object.CopyFromDateTimeString('2013-07-08 21:30:45')
     self.assertEqual(cocoa_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 395011845.546875
-    cocoa_time_object.CopyFromString('2013-07-08 21:30:45.546875')
+    cocoa_time_object.CopyFromDateTimeString('2013-07-08 21:30:45.546875')
     self.assertEqual(cocoa_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 395015445.546875
-    cocoa_time_object.CopyFromString('2013-07-08 21:30:45.546875-01:00')
+    cocoa_time_object.CopyFromDateTimeString('2013-07-08 21:30:45.546875-01:00')
     self.assertEqual(cocoa_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 395008245.546875
-    cocoa_time_object.CopyFromString('2013-07-08 21:30:45.546875+01:00')
+    cocoa_time_object.CopyFromDateTimeString('2013-07-08 21:30:45.546875+01:00')
     self.assertEqual(cocoa_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 86400.0
-    cocoa_time_object.CopyFromString('2001-01-02 00:00:00')
+    cocoa_time_object.CopyFromDateTimeString('2001-01-02 00:00:00')
     self.assertEqual(cocoa_time_object.timestamp, expected_timestamp)
 
   def testCopyToStatTimeTuple(self):

--- a/tests/delphi_date_time.py
+++ b/tests/delphi_date_time.py
@@ -10,7 +10,7 @@ from dfdatetime import delphi_date_time
 
 
 class DelphiDateTimeInvalidYear(delphi_date_time.DelphiDateTime):
-  """Delphi TDateTime timestamp for testing invalid year in CopyFromDateTimeString."""
+  """Delphi TDateTime timestamp for testing invalid year."""
 
   def _CopyDateTimeFromString(self, unused_time_string):
     """Copies a date and time from a string.
@@ -60,11 +60,13 @@ class DelphiDateTimeTest(unittest.TestCase):
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 41443.86806188513
-    delphi_date_time_object.CopyFromDateTimeString('2013-06-18 19:50:00.546875-01:00')
+    delphi_date_time_object.CopyFromDateTimeString(
+        '2013-06-18 19:50:00.546875-01:00')
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 41443.78472855179
-    delphi_date_time_object.CopyFromDateTimeString('2013-06-18 19:50:00.546875+01:00')
+    delphi_date_time_object.CopyFromDateTimeString(
+        '2013-06-18 19:50:00.546875+01:00')
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1.0

--- a/tests/delphi_date_time.py
+++ b/tests/delphi_date_time.py
@@ -10,7 +10,7 @@ from dfdatetime import delphi_date_time
 
 
 class DelphiDateTimeInvalidYear(delphi_date_time.DelphiDateTime):
-  """Delphi TDateTime timestamp for testing invalid year in CopyFromString."""
+  """Delphi TDateTime timestamp for testing invalid year in CopyFromDateTimeString."""
 
   def _CopyDateTimeFromString(self, unused_time_string):
     """Copies a date and time from a string.
@@ -43,38 +43,38 @@ class DelphiDateTimeInvalidYear(delphi_date_time.DelphiDateTime):
 class DelphiDateTimeTest(unittest.TestCase):
   """Tests for the Delphi TDateTime timestamp."""
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     delphi_date_time_object = delphi_date_time.DelphiDateTime()
 
     expected_timestamp = 41443.0
-    delphi_date_time_object.CopyFromString('2013-06-18')
+    delphi_date_time_object.CopyFromDateTimeString('2013-06-18')
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 41443.82638888889
-    delphi_date_time_object.CopyFromString('2013-06-18 19:50:00')
+    delphi_date_time_object.CopyFromDateTimeString('2013-06-18 19:50:00')
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 41443.826395218464
-    delphi_date_time_object.CopyFromString('2013-06-18 19:50:00.546875')
+    delphi_date_time_object.CopyFromDateTimeString('2013-06-18 19:50:00.546875')
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 41443.86806188513
-    delphi_date_time_object.CopyFromString('2013-06-18 19:50:00.546875-01:00')
+    delphi_date_time_object.CopyFromDateTimeString('2013-06-18 19:50:00.546875-01:00')
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 41443.78472855179
-    delphi_date_time_object.CopyFromString('2013-06-18 19:50:00.546875+01:00')
+    delphi_date_time_object.CopyFromDateTimeString('2013-06-18 19:50:00.546875+01:00')
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1.0
-    delphi_date_time_object.CopyFromString('1899-12-31 00:00:00')
+    delphi_date_time_object.CopyFromDateTimeString('1899-12-31 00:00:00')
     self.assertEqual(delphi_date_time_object.timestamp, expected_timestamp)
 
     delphi_date_time_object = DelphiDateTimeInvalidYear()
 
     with self.assertRaises(ValueError):
-      delphi_date_time_object.CopyFromString('9999-01-02 00:00:00')
+      delphi_date_time_object.CopyFromDateTimeString('9999-01-02 00:00:00')
 
   def testCopyToStatTimeTuple(self):
     """Tests the CopyToStatTimeTuple function."""

--- a/tests/fake_time.py
+++ b/tests/fake_time.py
@@ -14,42 +14,42 @@ class FakeTimeTest(unittest.TestCase):
 
   # pylint: disable=protected-access
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     fake_time_object = fake_time.FakeTime()
 
     expected_number_of_seconds = 1281571200
-    fake_time_object.CopyFromString('2010-08-12')
+    fake_time_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(
         fake_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertIsNone(fake_time_object._microseconds)
 
     expected_number_of_seconds = 1281647191
-    fake_time_object.CopyFromString('2010-08-12 21:06:31')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(
         fake_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertIsNone(fake_time_object._microseconds)
 
     expected_number_of_seconds = 1281647191
-    fake_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(
         fake_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(fake_time_object._microseconds, 546875)
 
     expected_number_of_seconds = 1281650791
-    fake_time_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         fake_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(fake_time_object._microseconds, 546875)
 
     expected_number_of_seconds = 1281643591
-    fake_time_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         fake_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(fake_time_object._microseconds, 546875)
 
     expected_number_of_seconds = -11644387200
-    fake_time_object.CopyFromString('1601-01-02 00:00:00')
+    fake_time_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(
         fake_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertIsNone(fake_time_object._microseconds)
@@ -57,14 +57,14 @@ class FakeTimeTest(unittest.TestCase):
   def testCopyToStatTimeTuple(self):
     """Tests the CopyToStatTimeTuple function."""
     fake_time_object = fake_time.FakeTime()
-    fake_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
 
     expected_stat_time_tuple = (1281647191, 5468750)
     stat_time_tuple = fake_time_object.CopyToStatTimeTuple()
     self.assertEqual(stat_time_tuple, expected_stat_time_tuple)
 
     fake_time_object = fake_time.FakeTime()
-    fake_time_object.CopyFromString('2010-08-12 21:06:31')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
 
     expected_stat_time_tuple = (1281647191, None)
     stat_time_tuple = fake_time_object.CopyToStatTimeTuple()
@@ -80,7 +80,7 @@ class FakeTimeTest(unittest.TestCase):
   def testCopyToDateTimeString(self):
     """Tests the CopyToDateTimeString function."""
     fake_time_object = fake_time.FakeTime()
-    fake_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
 
     date_time_string = fake_time_object.CopyToDateTimeString()
     self.assertEqual(date_time_string, '2010-08-12 21:06:31.546875')
@@ -94,7 +94,7 @@ class FakeTimeTest(unittest.TestCase):
   def testGetPlasoTimestamp(self):
     """Tests the GetPlasoTimestamp function."""
     fake_time_object = fake_time.FakeTime()
-    fake_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
 
     expected_micro_posix_number_of_seconds = 1281647191546875
     micro_posix_number_of_seconds = fake_time_object.GetPlasoTimestamp()
@@ -102,7 +102,7 @@ class FakeTimeTest(unittest.TestCase):
         micro_posix_number_of_seconds, expected_micro_posix_number_of_seconds)
 
     fake_time_object = fake_time.FakeTime()
-    fake_time_object.CopyFromString('2010-08-12 21:06:31')
+    fake_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
 
     expected_micro_posix_number_of_seconds = 1281647191000000
     micro_posix_number_of_seconds = fake_time_object.GetPlasoTimestamp()

--- a/tests/fat_date_time.py
+++ b/tests/fat_date_time.py
@@ -34,12 +34,14 @@ class FATDateTime(unittest.TestCase):
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 
     expected_number_of_seconds = 966117991
-    fat_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
+    fat_date_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 
     expected_number_of_seconds = 966110791
-    fat_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
+    fat_date_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 

--- a/tests/fat_date_time.py
+++ b/tests/fat_date_time.py
@@ -14,42 +14,42 @@ class FATDateTime(unittest.TestCase):
 
   # pylint: disable=protected-access
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     fat_date_time_object = fat_date_time.FATDateTime()
 
     expected_number_of_seconds = 966038400
-    fat_date_time_object.CopyFromString('2010-08-12')
+    fat_date_time_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 
     expected_number_of_seconds = 966114391
-    fat_date_time_object.CopyFromString('2010-08-12 21:06:31')
+    fat_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 
     expected_number_of_seconds = 966114391
-    fat_date_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    fat_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 
     expected_number_of_seconds = 966117991
-    fat_date_time_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    fat_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 
     expected_number_of_seconds = 966110791
-    fat_date_time_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    fat_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 
     expected_number_of_seconds = 86400
-    fat_date_time_object.CopyFromString('1980-01-02 00:00:00')
+    fat_date_time_object.CopyFromDateTimeString('1980-01-02 00:00:00')
     self.assertEqual(
         fat_date_time_object._number_of_seconds, expected_number_of_seconds)
 
     with self.assertRaises(ValueError):
-      fat_date_time_object.CopyFromString('2200-01-02 00:00:00')
+      fat_date_time_object.CopyFromDateTimeString('2200-01-02 00:00:00')
 
   def testGetNumberOfSeconds(self):
     """Tests the _GetNumberOfSeconds function."""

--- a/tests/filetime.py
+++ b/tests/filetime.py
@@ -12,36 +12,36 @@ from dfdatetime import filetime
 class FiletimeTest(unittest.TestCase):
   """Tests for the FILETIME timestamp."""
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     filetime_object = filetime.Filetime()
 
     expected_timestamp = 0x1cb39b14e8c4000
-    filetime_object.CopyFromString('2010-08-12')
+    filetime_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(filetime_object.timestamp, expected_timestamp)
 
     expected_timestamp = 0x1cb3a623cb6a580
-    filetime_object.CopyFromString('2010-08-12 21:06:31')
+    filetime_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(filetime_object.timestamp, expected_timestamp)
 
     expected_timestamp = 0x01cb3a623d0a17ce
-    filetime_object.CopyFromString('2010-08-12 21:06:31.546875')
+    filetime_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(filetime_object.timestamp, expected_timestamp)
 
     expected_timestamp = 0x1cb3a6a9ece7fce
-    filetime_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    filetime_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(filetime_object.timestamp, expected_timestamp)
 
     expected_timestamp = 0x1cb3a59db45afce
-    filetime_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    filetime_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(filetime_object.timestamp, expected_timestamp)
 
     expected_timestamp = 86400 * 10000000
-    filetime_object.CopyFromString('1601-01-02 00:00:00')
+    filetime_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(filetime_object.timestamp, expected_timestamp)
 
     with self.assertRaises(ValueError):
-      filetime_object.CopyFromString('1500-01-02 00:00:00')
+      filetime_object.CopyFromDateTimeString('1500-01-02 00:00:00')
 
   def testCopyToStatTimeTuple(self):
     """Tests the CopyToStatTimeTuple function."""

--- a/tests/hfs_time.py
+++ b/tests/hfs_time.py
@@ -12,36 +12,36 @@ from dfdatetime import hfs_time
 class HFSTimeTest(unittest.TestCase):
   """Tests for the HFS timestamp."""
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     hfs_time_object = hfs_time.HFSTime()
 
     expected_timestamp = 3458160000
-    hfs_time_object.CopyFromString('2013-08-01')
+    hfs_time_object.CopyFromDateTimeString('2013-08-01')
     self.assertEqual(hfs_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 3458215528
-    hfs_time_object.CopyFromString('2013-08-01 15:25:28')
+    hfs_time_object.CopyFromDateTimeString('2013-08-01 15:25:28')
     self.assertEqual(hfs_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 3458215528
-    hfs_time_object.CopyFromString('2013-08-01 15:25:28.546875')
+    hfs_time_object.CopyFromDateTimeString('2013-08-01 15:25:28.546875')
     self.assertEqual(hfs_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 3458219128
-    hfs_time_object.CopyFromString('2013-08-01 15:25:28.546875-01:00')
+    hfs_time_object.CopyFromDateTimeString('2013-08-01 15:25:28.546875-01:00')
     self.assertEqual(hfs_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 3458211928
-    hfs_time_object.CopyFromString('2013-08-01 15:25:28.546875+01:00')
+    hfs_time_object.CopyFromDateTimeString('2013-08-01 15:25:28.546875+01:00')
     self.assertEqual(hfs_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 86400
-    hfs_time_object.CopyFromString('1904-01-02 00:00:00')
+    hfs_time_object.CopyFromDateTimeString('1904-01-02 00:00:00')
     self.assertEqual(hfs_time_object.timestamp, expected_timestamp)
 
     with self.assertRaises(ValueError):
-      hfs_time_object.CopyFromString('1600-01-02 00:00:00')
+      hfs_time_object.CopyFromDateTimeString('1600-01-02 00:00:00')
 
   def testCopyToStatTimeTuple(self):
     """Tests the CopyToStatTimeTuple function."""

--- a/tests/java_time.py
+++ b/tests/java_time.py
@@ -12,32 +12,32 @@ from dfdatetime import java_time
 class JavaTimeTest(unittest.TestCase):
   """Tests for the Java java.util.Date timestamp."""
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     java_time_object = java_time.JavaTime()
 
     expected_timestamp = 1281571200000
-    java_time_object.CopyFromString('2010-08-12')
+    java_time_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(java_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281647191000
-    java_time_object.CopyFromString('2010-08-12 21:06:31')
+    java_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(java_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281647191546
-    java_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    java_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(java_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281650791546
-    java_time_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    java_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(java_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281643591546
-    java_time_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    java_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(java_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = -11644387200000
-    java_time_object.CopyFromString('1601-01-02 00:00:00')
+    java_time_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(java_time_object.timestamp, expected_timestamp)
 
   def testCopyToStatTimeTuple(self):

--- a/tests/posix_time.py
+++ b/tests/posix_time.py
@@ -12,32 +12,32 @@ from dfdatetime import posix_time
 class PosixTimeTest(unittest.TestCase):
   """Tests for the POSIX timestamp."""
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     posix_time_object = posix_time.PosixTime()
 
     expected_timestamp = 1281571200
-    posix_time_object.CopyFromString('2010-08-12')
+    posix_time_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281647191
-    posix_time_object.CopyFromString('2010-08-12 21:06:31')
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281647191
-    posix_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281650791
-    posix_time_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281643591
-    posix_time_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = -11644387200
-    posix_time_object.CopyFromString('1601-01-02 00:00:00')
+    posix_time_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
   def testCopyToStatTimeTuple(self):
@@ -83,32 +83,32 @@ class PosixTimeTest(unittest.TestCase):
 class PosixTimeInMicrosecondsTest(unittest.TestCase):
   """Tests for the POSIX timestamp in microseconds."""
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     posix_time_object = posix_time.PosixTimeInMicroseconds()
 
     expected_timestamp = 1281571200000000
-    posix_time_object.CopyFromString('2010-08-12')
+    posix_time_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281647191000000
-    posix_time_object.CopyFromString('2010-08-12 21:06:31')
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281647191546875
-    posix_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281650791546875
-    posix_time_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 1281643591546875
-    posix_time_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = -11644387200000000
-    posix_time_object.CopyFromString('1601-01-02 00:00:00')
+    posix_time_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(posix_time_object.timestamp, expected_timestamp)
 
   def testCopyToStatTimeTuple(self):

--- a/tests/rfc2579_date_time.py
+++ b/tests/rfc2579_date_time.py
@@ -10,7 +10,7 @@ from dfdatetime import rfc2579_date_time
 
 
 class RFC2579DateTimeInvalidYear(rfc2579_date_time.RFC2579DateTime):
-  """RFC2579 date-time for testing invalid year in CopyFromDateTimeString."""
+  """RFC2579 date-time for testing invalid year."""
 
   def _CopyDateTimeFromString(self, unused_time_string):
     """Copies a date and time from a string.
@@ -134,7 +134,8 @@ class RFC2579DateTimeTest(unittest.TestCase):
     self.assertEqual(rfc2579_date_time_object.deciseconds, 0)
 
     expected_number_of_seconds = 1281647191
-    rfc2579_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
+    rfc2579_date_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 2010)
@@ -146,7 +147,8 @@ class RFC2579DateTimeTest(unittest.TestCase):
     self.assertEqual(rfc2579_date_time_object.deciseconds, 5)
 
     expected_number_of_seconds = 1281650791
-    rfc2579_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
+    rfc2579_date_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 2010)
@@ -158,7 +160,8 @@ class RFC2579DateTimeTest(unittest.TestCase):
     self.assertEqual(rfc2579_date_time_object.deciseconds, 5)
 
     expected_number_of_seconds = 1281643591
-    rfc2579_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
+    rfc2579_date_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 2010)

--- a/tests/rfc2579_date_time.py
+++ b/tests/rfc2579_date_time.py
@@ -10,7 +10,7 @@ from dfdatetime import rfc2579_date_time
 
 
 class RFC2579DateTimeInvalidYear(rfc2579_date_time.RFC2579DateTime):
-  """RFC2579 date-time for testing invalid year in CopyFromString."""
+  """RFC2579 date-time for testing invalid year in CopyFromDateTimeString."""
 
   def _CopyDateTimeFromString(self, unused_time_string):
     """Copies a date and time from a string.
@@ -105,12 +105,12 @@ class RFC2579DateTimeTest(unittest.TestCase):
       rfc2579_date_time.RFC2579DateTime(
           rfc2579_date_time_tuple=(2010, 8, 12, 20, 6, 31, 6, '+', 2, 60))
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     rfc2579_date_time_object = rfc2579_date_time.RFC2579DateTime()
 
     expected_number_of_seconds = 1281571200
-    rfc2579_date_time_object.CopyFromString('2010-08-12')
+    rfc2579_date_time_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 2010)
@@ -122,7 +122,7 @@ class RFC2579DateTimeTest(unittest.TestCase):
     self.assertEqual(rfc2579_date_time_object.deciseconds, 0)
 
     expected_number_of_seconds = 1281647191
-    rfc2579_date_time_object.CopyFromString('2010-08-12 21:06:31')
+    rfc2579_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 2010)
@@ -134,7 +134,7 @@ class RFC2579DateTimeTest(unittest.TestCase):
     self.assertEqual(rfc2579_date_time_object.deciseconds, 0)
 
     expected_number_of_seconds = 1281647191
-    rfc2579_date_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    rfc2579_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 2010)
@@ -146,7 +146,7 @@ class RFC2579DateTimeTest(unittest.TestCase):
     self.assertEqual(rfc2579_date_time_object.deciseconds, 5)
 
     expected_number_of_seconds = 1281650791
-    rfc2579_date_time_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    rfc2579_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 2010)
@@ -158,7 +158,7 @@ class RFC2579DateTimeTest(unittest.TestCase):
     self.assertEqual(rfc2579_date_time_object.deciseconds, 5)
 
     expected_number_of_seconds = 1281643591
-    rfc2579_date_time_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    rfc2579_date_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 2010)
@@ -170,7 +170,7 @@ class RFC2579DateTimeTest(unittest.TestCase):
     self.assertEqual(rfc2579_date_time_object.deciseconds, 5)
 
     expected_number_of_seconds = -11644387200
-    rfc2579_date_time_object.CopyFromString('1601-01-02 00:00:00')
+    rfc2579_date_time_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(
         rfc2579_date_time_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(rfc2579_date_time_object.year, 1601)
@@ -184,7 +184,7 @@ class RFC2579DateTimeTest(unittest.TestCase):
     rfc2579_date_time_object = RFC2579DateTimeInvalidYear()
 
     with self.assertRaises(ValueError):
-      rfc2579_date_time_object.CopyFromString('9999-01-02 00:00:00')
+      rfc2579_date_time_object.CopyFromDateTimeString('9999-01-02 00:00:00')
 
   def testCopyToStatTimeTuple(self):
     """Tests the CopyToStatTimeTuple function."""

--- a/tests/semantic_time.py
+++ b/tests/semantic_time.py
@@ -14,11 +14,11 @@ class SemanticTimeTest(unittest.TestCase):
 
   # pylint: disable=protected-access
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     semantic_time_object = semantic_time.SemanticTime()
 
-    semantic_time_object.CopyFromString('Never')
+    semantic_time_object.CopyFromDateTimeString('Never')
     self.assertEqual(semantic_time_object.string, 'Never')
 
   def testCopyToStatTimeTuple(self):

--- a/tests/semantic_time.py
+++ b/tests/semantic_time.py
@@ -21,6 +21,13 @@ class SemanticTimeTest(unittest.TestCase):
     semantic_time_object.CopyFromDateTimeString('Never')
     self.assertEqual(semantic_time_object.string, 'Never')
 
+  def testCopyToDateTimeString(self):
+    """Tests the CopyToDateTimeString function."""
+    semantic_time_object = semantic_time.SemanticTime(string='Never')
+
+    date_time_string = semantic_time_object.CopyToDateTimeString()
+    self.assertEqual(date_time_string, 'Never')
+
   def testCopyToStatTimeTuple(self):
     """Tests the CopyToStatTimeTuple function."""
     semantic_time_object = semantic_time.SemanticTime()

--- a/tests/systemtime.py
+++ b/tests/systemtime.py
@@ -66,12 +66,12 @@ class FiletimeTest(unittest.TestCase):
       systemtime.Systemtime(
           system_time_tuple=(2010, 8, 4, 12, 20, 6, 31, 1001))
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     systemtime_object = systemtime.Systemtime()
 
     expected_number_of_seconds = 1281571200
-    systemtime_object.CopyFromString('2010-08-12')
+    systemtime_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(
         systemtime_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(systemtime_object.year, 2010)
@@ -83,7 +83,7 @@ class FiletimeTest(unittest.TestCase):
     self.assertEqual(systemtime_object.milliseconds, 0)
 
     expected_number_of_seconds = 1281647191
-    systemtime_object.CopyFromString('2010-08-12 21:06:31')
+    systemtime_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(
         systemtime_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(systemtime_object.year, 2010)
@@ -95,7 +95,7 @@ class FiletimeTest(unittest.TestCase):
     self.assertEqual(systemtime_object.milliseconds, 0)
 
     expected_number_of_seconds = 1281647191
-    systemtime_object.CopyFromString('2010-08-12 21:06:31.546875')
+    systemtime_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(
         systemtime_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(systemtime_object.year, 2010)
@@ -107,7 +107,7 @@ class FiletimeTest(unittest.TestCase):
     self.assertEqual(systemtime_object.milliseconds, 546)
 
     expected_number_of_seconds = 1281650791
-    systemtime_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    systemtime_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         systemtime_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(systemtime_object.year, 2010)
@@ -119,7 +119,7 @@ class FiletimeTest(unittest.TestCase):
     self.assertEqual(systemtime_object.milliseconds, 546)
 
     expected_number_of_seconds = 1281643591
-    systemtime_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    systemtime_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         systemtime_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(systemtime_object.year, 2010)
@@ -131,7 +131,7 @@ class FiletimeTest(unittest.TestCase):
     self.assertEqual(systemtime_object.milliseconds, 546)
 
     expected_number_of_seconds = -11644387200
-    systemtime_object.CopyFromString('1601-01-02 00:00:00')
+    systemtime_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(
         systemtime_object._number_of_seconds, expected_number_of_seconds)
     self.assertEqual(systemtime_object.year, 1601)
@@ -143,7 +143,7 @@ class FiletimeTest(unittest.TestCase):
     self.assertEqual(systemtime_object.milliseconds, 0)
 
     with self.assertRaises(ValueError):
-      systemtime_object.CopyFromString('1600-01-02 00:00:00')
+      systemtime_object.CopyFromDateTimeString('1600-01-02 00:00:00')
 
   def testCopyToStatTimeTuple(self):
     """Tests the CopyToStatTimeTuple function."""

--- a/tests/time_elements.py
+++ b/tests/time_elements.py
@@ -271,7 +271,8 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
+    time_elements_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -279,7 +280,8 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
+    time_elements_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -293,13 +295,13 @@ class TimeElementsTest(unittest.TestCase):
     self.assertEqual(
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
-  def testCopyFromDateTimeStringISO8601(self):
-    """Tests the CopyFromDateTimeStringISO8601 function."""
+  def testCopyFromStringISO8601(self):
+    """Tests the CopyFromStringISO8601 function."""
     time_elements_object = time_elements.TimeElements()
 
     expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0)
     expected_number_of_seconds = 1281571200
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12')
+    time_elements_object.CopyFromStringISO8601('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -307,7 +309,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -315,7 +317,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31Z')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -323,7 +325,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.5')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.5')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -331,7 +333,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.546875')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -339,7 +341,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31,546875')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31,546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -347,7 +349,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2012, 3, 5, 20, 40, 0)
     expected_number_of_seconds = 1330980000
-    time_elements_object.CopyFromDateTimeStringISO8601('2012-03-05T20:40:00.0000000Z')
+    time_elements_object.CopyFromStringISO8601('2012-03-05T20:40:00.0000000Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -355,7 +357,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromDateTimeStringISO8601(
+    time_elements_object.CopyFromStringISO8601(
         '2010-08-12T21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -364,7 +366,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromDateTimeStringISO8601(
+    time_elements_object.CopyFromStringISO8601(
         '2010-08-12T21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -372,24 +374,24 @@ class TimeElementsTest(unittest.TestCase):
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601(None)
+      time_elements_object.CopyFromStringISO8601(None)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601(
+      time_elements_object.CopyFromStringISO8601(
           '2010-08-12 21:06:31.546875+01:00')
 
     # Valid ISO 8601 notations currently not supported.
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33')
+      time_elements_object.CopyFromStringISO8601('2016-W33')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33-3')
+      time_elements_object.CopyFromStringISO8601('2016-W33-3')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('--08-17')
+      time_elements_object.CopyFromStringISO8601('--08-17')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-230')
+      time_elements_object.CopyFromStringISO8601('2016-230')
 
   def testCopyFromDateTimeStringTuple(self):
     """Tests the CopyFromDateTimeStringTuple function."""
@@ -554,13 +556,13 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
     self.assertEqual(
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
-  def testCopyFromDateTimeStringISO8601(self):
-    """Tests the CopyFromDateTimeStringISO8601 function."""
+  def testCopyFromStringISO8601(self):
+    """Tests the CopyFromStringISO8601 function."""
     time_elements_object = time_elements.TimeElementsInMilliseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0, 0)
     expected_number_of_seconds = 1281571200
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12')
+    time_elements_object.CopyFromStringISO8601('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -568,7 +570,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -576,7 +578,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31Z')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -584,7 +586,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 500)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.5')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.5')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -592,7 +594,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.546875')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -600,7 +602,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31,546875')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31,546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -608,7 +610,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2012, 3, 5, 20, 40, 0, 0)
     expected_number_of_seconds = 1330980000
-    time_elements_object.CopyFromDateTimeStringISO8601('2012-03-05T20:40:00.0000000Z')
+    time_elements_object.CopyFromStringISO8601('2012-03-05T20:40:00.0000000Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -616,7 +618,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31, 546)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromDateTimeStringISO8601(
+    time_elements_object.CopyFromStringISO8601(
         '2010-08-12T21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -625,7 +627,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31, 546)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromDateTimeStringISO8601(
+    time_elements_object.CopyFromStringISO8601(
         '2010-08-12T21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -633,24 +635,24 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601(None)
+      time_elements_object.CopyFromStringISO8601(None)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601(
+      time_elements_object.CopyFromStringISO8601(
           '2010-08-12 21:06:31.546875+01:00')
 
     # Valid ISO 8601 notations currently not supported.
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33')
+      time_elements_object.CopyFromStringISO8601('2016-W33')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33-3')
+      time_elements_object.CopyFromStringISO8601('2016-W33-3')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('--08-17')
+      time_elements_object.CopyFromStringISO8601('--08-17')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-230')
+      time_elements_object.CopyFromStringISO8601('2016-230')
 
   def testCopyFromDateTimeStringTuple(self):
     """Tests the CopyFromDateTimeStringTuple function."""
@@ -796,13 +798,13 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
     self.assertEqual(
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
-  def testCopyFromDateTimeStringISO8601(self):
-    """Tests the CopyFromDateTimeStringISO8601 function."""
+  def testCopyFromStringISO8601(self):
+    """Tests the CopyFromStringISO8601 function."""
     time_elements_object = time_elements.TimeElementsInMicroseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0, 0)
     expected_number_of_seconds = 1281571200
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12')
+    time_elements_object.CopyFromStringISO8601('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -810,7 +812,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -818,7 +820,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31Z')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -826,7 +828,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 500000)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.5')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.5')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -834,7 +836,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546875)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.546875')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -842,7 +844,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546875)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31,546875')
+    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31,546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -850,7 +852,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2012, 3, 5, 20, 40, 0, 0)
     expected_number_of_seconds = 1330980000
-    time_elements_object.CopyFromDateTimeStringISO8601('2012-03-05T20:40:00.0000000Z')
+    time_elements_object.CopyFromStringISO8601('2012-03-05T20:40:00.0000000Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -858,7 +860,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31, 546875)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromDateTimeStringISO8601(
+    time_elements_object.CopyFromStringISO8601(
         '2010-08-12T21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -867,7 +869,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31, 546875)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromDateTimeStringISO8601(
+    time_elements_object.CopyFromStringISO8601(
         '2010-08-12T21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -875,24 +877,24 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601(None)
+      time_elements_object.CopyFromStringISO8601(None)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601(
+      time_elements_object.CopyFromStringISO8601(
           '2010-08-12 21:06:31.546875+01:00')
 
     # Valid ISO 8601 notations currently not supported.
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33')
+      time_elements_object.CopyFromStringISO8601('2016-W33')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33-3')
+      time_elements_object.CopyFromStringISO8601('2016-W33-3')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('--08-17')
+      time_elements_object.CopyFromStringISO8601('--08-17')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringISO8601('2016-230')
+      time_elements_object.CopyFromStringISO8601('2016-230')
 
   def testCopyFromDateTimeStringTuple(self):
     """Tests the CopyFromDateTimeStringTuple function."""

--- a/tests/time_elements.py
+++ b/tests/time_elements.py
@@ -241,9 +241,13 @@ class TimeElementsTest(unittest.TestCase):
     self.assertEqual(
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
-    expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
-    expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromString('2010-08-12 21:06:31')
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
+    time_elements_object = time_elements.TimeElements()
+
+    expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0)
+    expected_number_of_seconds = 1281571200
+    time_elements_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -251,7 +255,15 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31')
+    self.assertEqual(
+        time_elements_object._time_elements_tuple, expected_time_elements_tuple)
+    self.assertEqual(
+        time_elements_object._number_of_seconds, expected_number_of_seconds)
+
+    expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
+    expected_number_of_seconds = 1281647191
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -259,7 +271,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -267,7 +279,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -275,19 +287,19 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (1601, 1, 2, 0, 0, 0)
     expected_number_of_seconds = -11644387200
-    time_elements_object.CopyFromString('1601-01-02 00:00:00')
+    time_elements_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
-  def testCopyFromStringISO8601(self):
-    """Tests the CopyFromStringISO8601 function."""
+  def testCopyFromDateTimeStringISO8601(self):
+    """Tests the CopyFromDateTimeStringISO8601 function."""
     time_elements_object = time_elements.TimeElements()
 
     expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0)
     expected_number_of_seconds = 1281571200
-    time_elements_object.CopyFromStringISO8601('2010-08-12')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -295,7 +307,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -303,7 +315,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31Z')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -311,7 +323,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.5')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.5')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -319,7 +331,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.546875')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -327,7 +339,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31,546875')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31,546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -335,7 +347,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2012, 3, 5, 20, 40, 0)
     expected_number_of_seconds = 1330980000
-    time_elements_object.CopyFromStringISO8601('2012-03-05T20:40:00.0000000Z')
+    time_elements_object.CopyFromDateTimeStringISO8601('2012-03-05T20:40:00.0000000Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -343,7 +355,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromStringISO8601(
+    time_elements_object.CopyFromDateTimeStringISO8601(
         '2010-08-12T21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -352,7 +364,7 @@ class TimeElementsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromStringISO8601(
+    time_elements_object.CopyFromDateTimeStringISO8601(
         '2010-08-12T21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -360,62 +372,62 @@ class TimeElementsTest(unittest.TestCase):
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601(None)
+      time_elements_object.CopyFromDateTimeStringISO8601(None)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601(
+      time_elements_object.CopyFromDateTimeStringISO8601(
           '2010-08-12 21:06:31.546875+01:00')
 
     # Valid ISO 8601 notations currently not supported.
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-W33')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-W33-3')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33-3')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('--08-17')
+      time_elements_object.CopyFromDateTimeStringISO8601('--08-17')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-230')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-230')
 
-  def testCopyFromStringTuple(self):
-    """Tests the CopyFromStringTuple function."""
+  def testCopyFromDateTimeStringTuple(self):
+    """Tests the CopyFromDateTimeStringTuple function."""
     time_elements_object = time_elements.TimeElements()
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
-    time_elements_object.CopyFromStringTuple(
+    time_elements_object.CopyFromDateTimeStringTuple(
         time_elements_tuple=('2010', '8', '12', '20', '6', '31'))
     self.assertIsNotNone(time_elements_object)
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('20A0', 'B', '12', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', 'B', '12', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '1C', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '12', 'D0', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', 'E', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', 'F1'))
 
   def testCopyToStatTimeTuple(self):
@@ -490,13 +502,13 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
   # TODO: add tests for _CopyFromDateTimeValues
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     time_elements_object = time_elements.TimeElementsInMilliseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0, 0)
     expected_number_of_seconds = 1281571200
-    time_elements_object.CopyFromString('2010-08-12')
+    time_elements_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -504,7 +516,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromString('2010-08-12 21:06:31')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -512,7 +524,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -520,7 +532,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31, 546)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -528,7 +540,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31, 546)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -536,19 +548,19 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (1601, 1, 2, 0, 0, 0, 0)
     expected_number_of_seconds = -11644387200
-    time_elements_object.CopyFromString('1601-01-02 00:00:00')
+    time_elements_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
-  def testCopyFromStringISO8601(self):
-    """Tests the CopyFromStringISO8601 function."""
+  def testCopyFromDateTimeStringISO8601(self):
+    """Tests the CopyFromDateTimeStringISO8601 function."""
     time_elements_object = time_elements.TimeElementsInMilliseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0, 0)
     expected_number_of_seconds = 1281571200
-    time_elements_object.CopyFromStringISO8601('2010-08-12')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -556,7 +568,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -564,7 +576,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31Z')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -572,7 +584,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 500)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.5')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.5')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -580,7 +592,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.546875')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -588,7 +600,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31,546875')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31,546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -596,7 +608,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2012, 3, 5, 20, 40, 0, 0)
     expected_number_of_seconds = 1330980000
-    time_elements_object.CopyFromStringISO8601('2012-03-05T20:40:00.0000000Z')
+    time_elements_object.CopyFromDateTimeStringISO8601('2012-03-05T20:40:00.0000000Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -604,7 +616,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31, 546)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromStringISO8601(
+    time_elements_object.CopyFromDateTimeStringISO8601(
         '2010-08-12T21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -613,7 +625,7 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31, 546)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromStringISO8601(
+    time_elements_object.CopyFromDateTimeStringISO8601(
         '2010-08-12T21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -621,31 +633,31 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601(None)
+      time_elements_object.CopyFromDateTimeStringISO8601(None)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601(
+      time_elements_object.CopyFromDateTimeStringISO8601(
           '2010-08-12 21:06:31.546875+01:00')
 
     # Valid ISO 8601 notations currently not supported.
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-W33')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-W33-3')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33-3')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('--08-17')
+      time_elements_object.CopyFromDateTimeStringISO8601('--08-17')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-230')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-230')
 
-  def testCopyFromStringTuple(self):
-    """Tests the CopyFromStringTuple function."""
+  def testCopyFromDateTimeStringTuple(self):
+    """Tests the CopyFromDateTimeStringTuple function."""
     time_elements_object = time_elements.TimeElementsInMilliseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
-    time_elements_object.CopyFromStringTuple(
+    time_elements_object.CopyFromDateTimeStringTuple(
         time_elements_tuple=('2010', '8', '12', '20', '6', '31', '546'))
     self.assertIsNotNone(time_elements_object)
     self.assertEqual(
@@ -653,11 +665,11 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
     self.assertEqual(time_elements_object._milliseconds, 546)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', '31', '9S'))
 
   def testCopyToStatTimeTuple(self):
@@ -732,13 +744,13 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
   # TODO: add tests for _CopyFromDateTimeValues
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     time_elements_object = time_elements.TimeElementsInMicroseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0, 0)
     expected_number_of_seconds = 1281571200
-    time_elements_object.CopyFromString('2010-08-12')
+    time_elements_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -746,7 +758,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromString('2010-08-12 21:06:31')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -754,7 +766,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546875)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -762,7 +774,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31, 546875)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -770,7 +782,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31, 546875)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -778,19 +790,19 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (1601, 1, 2, 0, 0, 0, 0)
     expected_number_of_seconds = -11644387200
-    time_elements_object.CopyFromString('1601-01-02 00:00:00')
+    time_elements_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
-  def testCopyFromStringISO8601(self):
-    """Tests the CopyFromStringISO8601 function."""
+  def testCopyFromDateTimeStringISO8601(self):
+    """Tests the CopyFromDateTimeStringISO8601 function."""
     time_elements_object = time_elements.TimeElementsInMicroseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 0, 0, 0, 0)
     expected_number_of_seconds = 1281571200
-    time_elements_object.CopyFromStringISO8601('2010-08-12')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -798,7 +810,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -806,7 +818,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 0)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31Z')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -814,7 +826,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 500000)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.5')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.5')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -822,7 +834,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546875)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31.546875')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31.546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -830,7 +842,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 21, 6, 31, 546875)
     expected_number_of_seconds = 1281647191
-    time_elements_object.CopyFromStringISO8601('2010-08-12T21:06:31,546875')
+    time_elements_object.CopyFromDateTimeStringISO8601('2010-08-12T21:06:31,546875')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -838,7 +850,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2012, 3, 5, 20, 40, 0, 0)
     expected_number_of_seconds = 1330980000
-    time_elements_object.CopyFromStringISO8601('2012-03-05T20:40:00.0000000Z')
+    time_elements_object.CopyFromDateTimeStringISO8601('2012-03-05T20:40:00.0000000Z')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -846,7 +858,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31, 546875)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromStringISO8601(
+    time_elements_object.CopyFromDateTimeStringISO8601(
         '2010-08-12T21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -855,7 +867,7 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31, 546875)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromStringISO8601(
+    time_elements_object.CopyFromDateTimeStringISO8601(
         '2010-08-12T21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
@@ -863,31 +875,31 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
         time_elements_object._number_of_seconds, expected_number_of_seconds)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601(None)
+      time_elements_object.CopyFromDateTimeStringISO8601(None)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601(
+      time_elements_object.CopyFromDateTimeStringISO8601(
           '2010-08-12 21:06:31.546875+01:00')
 
     # Valid ISO 8601 notations currently not supported.
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-W33')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-W33-3')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-W33-3')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('--08-17')
+      time_elements_object.CopyFromDateTimeStringISO8601('--08-17')
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringISO8601('2016-230')
+      time_elements_object.CopyFromDateTimeStringISO8601('2016-230')
 
-  def testCopyFromStringTuple(self):
-    """Tests the CopyFromStringTuple function."""
+  def testCopyFromDateTimeStringTuple(self):
+    """Tests the CopyFromDateTimeStringTuple function."""
     time_elements_object = time_elements.TimeElementsInMicroseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
-    time_elements_object.CopyFromStringTuple(
+    time_elements_object.CopyFromDateTimeStringTuple(
         time_elements_tuple=('2010', '8', '12', '20', '6', '31', '546'))
     self.assertIsNotNone(time_elements_object)
     self.assertEqual(
@@ -895,11 +907,11 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
     self.assertEqual(time_elements_object._microseconds, 546)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromStringTuple(
+      time_elements_object.CopyFromDateTimeStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', '31', '9S'))
 
   def testCopyToStatTimeTuple(self):

--- a/tests/time_elements.py
+++ b/tests/time_elements.py
@@ -534,7 +534,8 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31, 546)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
+    time_elements_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -542,7 +543,8 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31, 546)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
+    time_elements_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -776,7 +778,8 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 22, 6, 31, 546875)
     expected_number_of_seconds = 1281650791
-    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
+    time_elements_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(
@@ -784,7 +787,8 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31, 546875)
     expected_number_of_seconds = 1281643591
-    time_elements_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
+    time_elements_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
     self.assertEqual(

--- a/tests/time_elements.py
+++ b/tests/time_elements.py
@@ -393,43 +393,43 @@ class TimeElementsTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       time_elements_object.CopyFromStringISO8601('2016-230')
 
-  def testCopyFromDateTimeStringTuple(self):
-    """Tests the CopyFromDateTimeStringTuple function."""
+  def testCopyFromStringTuple(self):
+    """Tests the CopyFromStringTuple function."""
     time_elements_object = time_elements.TimeElements()
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
-    time_elements_object.CopyFromDateTimeStringTuple(
+    time_elements_object.CopyFromStringTuple(
         time_elements_tuple=('2010', '8', '12', '20', '6', '31'))
     self.assertIsNotNone(time_elements_object)
     self.assertEqual(
         time_elements_object._time_elements_tuple, expected_time_elements_tuple)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('20A0', 'B', '12', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', 'B', '12', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '1C', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '12', 'D0', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', 'E', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', 'F1'))
 
   def testCopyToStatTimeTuple(self):
@@ -656,12 +656,12 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       time_elements_object.CopyFromStringISO8601('2016-230')
 
-  def testCopyFromDateTimeStringTuple(self):
-    """Tests the CopyFromDateTimeStringTuple function."""
+  def testCopyFromStringTuple(self):
+    """Tests the CopyFromStringTuple function."""
     time_elements_object = time_elements.TimeElementsInMilliseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
-    time_elements_object.CopyFromDateTimeStringTuple(
+    time_elements_object.CopyFromStringTuple(
         time_elements_tuple=('2010', '8', '12', '20', '6', '31', '546'))
     self.assertIsNotNone(time_elements_object)
     self.assertEqual(
@@ -669,11 +669,11 @@ class TimeElementsInMillisecondsTest(unittest.TestCase):
     self.assertEqual(time_elements_object._milliseconds, 546)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', '31', '9S'))
 
   def testCopyToStatTimeTuple(self):
@@ -900,12 +900,12 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       time_elements_object.CopyFromStringISO8601('2016-230')
 
-  def testCopyFromDateTimeStringTuple(self):
-    """Tests the CopyFromDateTimeStringTuple function."""
+  def testCopyFromStringTuple(self):
+    """Tests the CopyFromStringTuple function."""
     time_elements_object = time_elements.TimeElementsInMicroseconds()
 
     expected_time_elements_tuple = (2010, 8, 12, 20, 6, 31)
-    time_elements_object.CopyFromDateTimeStringTuple(
+    time_elements_object.CopyFromStringTuple(
         time_elements_tuple=('2010', '8', '12', '20', '6', '31', '546'))
     self.assertIsNotNone(time_elements_object)
     self.assertEqual(
@@ -913,11 +913,11 @@ class TimeElementsInMicrosecondsTest(unittest.TestCase):
     self.assertEqual(time_elements_object._microseconds, 546)
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', '31'))
 
     with self.assertRaises(ValueError):
-      time_elements_object.CopyFromDateTimeStringTuple(
+      time_elements_object.CopyFromStringTuple(
           time_elements_tuple=('2010', '8', '12', '20', '6', '31', '9S'))
 
   def testCopyToStatTimeTuple(self):

--- a/tests/uuid_time.py
+++ b/tests/uuid_time.py
@@ -30,36 +30,36 @@ class UUIDTimeTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       uuid_time.UUIDTime(timestamp=-1)
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     uuid_time_object = uuid_time.UUIDTime()
 
     expected_timestamp = 135946080000000000
-    uuid_time_object.CopyFromString('2013-08-01')
+    uuid_time_object.CopyFromDateTimeString('2013-08-01')
     self.assertEqual(uuid_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 135946635280000000
-    uuid_time_object.CopyFromString('2013-08-01 15:25:28')
+    uuid_time_object.CopyFromDateTimeString('2013-08-01 15:25:28')
     self.assertEqual(uuid_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 135946635285468750
-    uuid_time_object.CopyFromString('2013-08-01 15:25:28.546875')
+    uuid_time_object.CopyFromDateTimeString('2013-08-01 15:25:28.546875')
     self.assertEqual(uuid_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 135946671285468750
-    uuid_time_object.CopyFromString('2013-08-01 15:25:28.546875-01:00')
+    uuid_time_object.CopyFromDateTimeString('2013-08-01 15:25:28.546875-01:00')
     self.assertEqual(uuid_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 135946599285468750
-    uuid_time_object.CopyFromString('2013-08-01 15:25:28.546875+01:00')
+    uuid_time_object.CopyFromDateTimeString('2013-08-01 15:25:28.546875+01:00')
     self.assertEqual(uuid_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 864000000000
-    uuid_time_object.CopyFromString('1582-10-16 00:00:00')
+    uuid_time_object.CopyFromDateTimeString('1582-10-16 00:00:00')
     self.assertEqual(uuid_time_object.timestamp, expected_timestamp)
 
     with self.assertRaises(ValueError):
-      uuid_time_object.CopyFromString('1570-01-02 00:00:00')
+      uuid_time_object.CopyFromDateTimeString('1570-01-02 00:00:00')
 
   def testCopyToStatTimeTuple(self):
     """Tests the CopyToStatTimeTuple function."""

--- a/tests/webkit_time.py
+++ b/tests/webkit_time.py
@@ -29,11 +29,13 @@ class WebKitTimeTest(unittest.TestCase):
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 12926124391546875
-    webkit_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
+    webkit_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 12926117191546875
-    webkit_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
+    webkit_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 86400 * 1000000

--- a/tests/webkit_time.py
+++ b/tests/webkit_time.py
@@ -12,32 +12,32 @@ from dfdatetime import webkit_time
 class WebKitTimeTest(unittest.TestCase):
   """Tests for the WebKit timestamp."""
 
-  def testCopyFromString(self):
-    """Tests the CopyFromString function."""
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
     webkit_time_object = webkit_time.WebKitTime()
 
     expected_timestamp = 12926044800000000
-    webkit_time_object.CopyFromString('2010-08-12')
+    webkit_time_object.CopyFromDateTimeString('2010-08-12')
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 12926120791000000
-    webkit_time_object.CopyFromString('2010-08-12 21:06:31')
+    webkit_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 12926120791546875
-    webkit_time_object.CopyFromString('2010-08-12 21:06:31.546875')
+    webkit_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875')
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 12926124391546875
-    webkit_time_object.CopyFromString('2010-08-12 21:06:31.546875-01:00')
+    webkit_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875-01:00')
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 12926117191546875
-    webkit_time_object.CopyFromString('2010-08-12 21:06:31.546875+01:00')
+    webkit_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.546875+01:00')
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
     expected_timestamp = 86400 * 1000000
-    webkit_time_object.CopyFromString('1601-01-02 00:00:00')
+    webkit_time_object.CopyFromDateTimeString('1601-01-02 00:00:00')
     self.assertEqual(webkit_time_object.timestamp, expected_timestamp)
 
   def testCopyToStatTimeTuple(self):


### PR DESCRIPTION
[Code review: 334340043: Deprecated CopyFromString in favor of CopyFromDatetimeString #73](https://codereview.appspot.com/334340043/)