### PR TITLE
343990043: Fixed typo in RFC2579 date time docstring

### DIFF
--- a/dfdatetime/rfc2579_date_time.py
+++ b/dfdatetime/rfc2579_date_time.py
@@ -24,7 +24,7 @@ class RFC2579DateTime(interface.DateTimeValues):
       uint8_t deciseconds,
       char direction_from_utc,
       uint8_t hours_from_utc,
-      uint8_t minuted_from_utc
+      uint8_t minutes_from_utc
   }
 
   Also see:


### PR DESCRIPTION
[Code review: 343990043: Fixed typo in RFC2579 date time docstring](https://codereview.appspot.com/343990043/)