### PR TITLE
357750043: Use Decimal.quantize instead of round() to support Python 2 and Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 # Code review files
 /.review
 
+# Pycharm files
+/.idea
+
 # Test coverage files
 .coverage
 tests-coverage.txt

--- a/dfdatetime/interface.py
+++ b/dfdatetime/interface.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import abc
 import calendar
+import decimal
 
 from dfdatetime import decorators
 from dfdatetime import definitions
@@ -932,7 +933,9 @@ class DateTimeValues(object):
       return None
 
     normalized_timestamp *= definitions.MICROSECONDS_PER_SECOND
-    return int(round(normalized_timestamp))
+    normalized_timestamp = normalized_timestamp.quantize(
+        1, rounding=decimal.ROUND_HALF_UP)
+    return int(normalized_timestamp)
 
   def GetTimeOfDay(self):
     """Retrieves the time of day represented by the date and time values.

--- a/tests/fake_time.py
+++ b/tests/fake_time.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import decimal
 import unittest
 
 from dfdatetime import fake_time
@@ -27,6 +28,15 @@ class FakeTimeTest(unittest.TestCase):
 
     normalized_timestamp = fake_time_object._GetNormalizedTimestamp()
     self.assertIsNone(normalized_timestamp)
+
+  def testGetPlasoTimestamp(self):
+    """Tests the GetPlasoTimestamp function."""
+    fake_time_object = fake_time.FakeTime()
+    fake_time_object._normalized_timestamp = decimal.Decimal(
+        '1333794697.6252465')
+    plaso_timestamp = fake_time_object.GetPlasoTimestamp()
+    self.assertEqual(plaso_timestamp, 1333794697625247)
+
 
   def testCopyFromDateTimeString(self):
     """Tests the CopyFromDateTimeString function."""

--- a/tests/fake_time.py
+++ b/tests/fake_time.py
@@ -37,7 +37,6 @@ class FakeTimeTest(unittest.TestCase):
     plaso_timestamp = fake_time_object.GetPlasoTimestamp()
     self.assertEqual(plaso_timestamp, 1333794697625247)
 
-
   def testCopyFromDateTimeString(self):
     """Tests the CopyFromDateTimeString function."""
     fake_time_object = fake_time.FakeTime()


### PR DESCRIPTION
[Code review: 357750043: Use Decimal.quantize instead of round() to support Python 2 and Python 3](https://codereview.appspot.com/357750043/)