### PR TITLE
moved APFSTime to PosixTimeInNanoseconds

### DIFF
--- a/dfdatetime/apfs_time.py
+++ b/dfdatetime/apfs_time.py
@@ -12,12 +12,12 @@ from dfdatetime import posix_time
 class APFSTime(posix_time.PosixTimeInNanoseconds):
   """Apple File System (APFS) timestamp.
 
-    The APFS timestamp is a signed 64-bit integer that contains the number of
-    nanoseconds since 1970-01-01 00:00:00.
+  The APFS timestamp is a signed 64-bit integer that contains the number of
+  nanoseconds since 1970-01-01 00:00:00.
 
-    Attributes:
-      is_local_time (bool): True if the date and time value is in local time.
-    """
+  Attributes:
+    is_local_time (bool): True if the date and time value is in local time.
+  """
 
   def _GetNormalizedTimestamp(self):
     """Retrieves the normalized timestamp.

--- a/dfdatetime/apfs_time.py
+++ b/dfdatetime/apfs_time.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 
 import decimal
 
-from dfdatetime import posix_time
 from dfdatetime import definitions
+from dfdatetime import posix_time
 
 
 class APFSTime(posix_time.PosixTimeInNanoseconds):
@@ -49,10 +49,10 @@ class APFSTime(posix_time.PosixTimeInNanoseconds):
           fraction and time zone offset are optional. The default time zone
           is UTC.
     """
-    self._CopyFromDateTimeString(time_string)
+    super(APFSTime, self)._CopyFromDateTimeString(time_string)
 
     # Maximum value for APFS time is 2262-04-11 16:47:16.854775807
-    if self._timestamp > self._INT64_MAX:
+    if self._timestamp > self._INT64_MAX or self._timestamp < self._INT64_MIN:
       raise ValueError('Date time value not supported.')
 
   def CopyToDateTimeString(self):
@@ -66,4 +66,4 @@ class APFSTime(posix_time.PosixTimeInNanoseconds):
         self._timestamp > self._INT64_MAX):
       return None
 
-    return self._CopyToDateTimeString()
+    return super(APFSTime, self)._CopyToDateTimeString()

--- a/dfdatetime/apfs_time.py
+++ b/dfdatetime/apfs_time.py
@@ -5,37 +5,19 @@ from __future__ import unicode_literals
 
 import decimal
 
-from dfdatetime import definitions
-from dfdatetime import interface
 from dfdatetime import posix_time
+from dfdatetime import definitions
 
 
-class APFSTime(interface.DateTimeValues):
+class APFSTime(posix_time.PosixTimeInNanoseconds):
   """Apple File System (APFS) timestamp.
 
-  The APFS timestamp is a signed 64-bit integer that contains the number of
-  nanoseconds since 1970-01-01 00:00:00.
+    The APFS timestamp is a signed 64-bit integer that contains the number of
+    nanoseconds since 1970-01-01 00:00:00.
 
-  Attributes:
-    is_local_time (bool): True if the date and time value is in local time.
-  """
-
-  _EPOCH = posix_time.PosixTimeEpoch()
-
-  def __init__(self, timestamp=None):
-    """Initializes an Apple File System (APFS) timestamp.
-
-    Args:
-      timestamp (Optional[int]): APFS timestamp.
+    Attributes:
+      is_local_time (bool): True if the date and time value is in local time.
     """
-    super(APFSTime, self).__init__()
-    self._precision = definitions.PRECISION_1_NANOSECOND
-    self._timestamp = timestamp
-
-  @property
-  def timestamp(self):
-    """int: APFS timestamp or None if timestamp is not set."""
-    return self._timestamp
 
   def _GetNormalizedTimestamp(self):
     """Retrieves the normalized timestamp.
@@ -67,30 +49,11 @@ class APFSTime(interface.DateTimeValues):
           fraction and time zone offset are optional. The default time zone
           is UTC.
     """
-    date_time_values = self._CopyDateTimeFromString(time_string)
-
-    year = date_time_values.get('year', 0)
-    month = date_time_values.get('month', 0)
-    day_of_month = date_time_values.get('day_of_month', 0)
-    hours = date_time_values.get('hours', 0)
-    minutes = date_time_values.get('minutes', 0)
-    seconds = date_time_values.get('seconds', 0)
-    microseconds = date_time_values.get('microseconds', None)
-
-    timestamp = self._GetNumberOfSecondsFromElements(
-        year, month, day_of_month, hours, minutes, seconds)
-    timestamp *= definitions.NANOSECONDS_PER_SECOND
-
-    if microseconds:
-      nanoseconds = microseconds * definitions.MILLISECONDS_PER_SECOND
-      timestamp += nanoseconds
+    self._CopyFromDateTimeString(time_string)
 
     # Maximum value for APFS time is 2262-04-11 16:47:16.854775807
-    if timestamp > self._INT64_MAX:
+    if self._timestamp > self._INT64_MAX:
       raise ValueError('Date time value not supported.')
-
-    self._normalized_timestamp = None
-    self._timestamp = timestamp
 
   def CopyToDateTimeString(self):
     """Copies the APFS timestamp to a date and time string.
@@ -99,16 +62,8 @@ class APFSTime(interface.DateTimeValues):
       str: date and time value formatted as: "YYYY-MM-DD hh:mm:ss.#########" or
           None if the timestamp is missing or invalid.
     """
-    if (self._timestamp is None or self._timestamp < self._INT64_MIN or
+    if (self._timestamp < self._INT64_MIN or
         self._timestamp > self._INT64_MAX):
       return None
 
-    timestamp, nanoseconds = divmod(
-        self._timestamp, definitions.NANOSECONDS_PER_SECOND)
-    number_of_days, hours, minutes, seconds = self._GetTimeValues(timestamp)
-
-    year, month, day_of_month = self._GetDateValuesWithEpoch(
-        number_of_days, self._EPOCH)
-
-    return '{0:04d}-{1:02d}-{2:02d} {3:02d}:{4:02d}:{5:02d}.{6:09d}'.format(
-        year, month, day_of_month, hours, minutes, seconds, nanoseconds)
+    return self._CopyToDateTimeString()

--- a/dfdatetime/apfs_time.py
+++ b/dfdatetime/apfs_time.py
@@ -51,8 +51,8 @@ class APFSTime(posix_time.PosixTimeInNanoseconds):
     """
     super(APFSTime, self)._CopyFromDateTimeString(time_string)
 
-    # Maximum value for APFS time is 2262-04-11 16:47:16.854775807
-    if self._timestamp > self._INT64_MAX or self._timestamp < self._INT64_MIN:
+    if (self._timestamp is None or self._timestamp < self._INT64_MIN or
+        self._timestamp > self._INT64_MAX):
       raise ValueError('Date time value not supported.')
 
   def CopyToDateTimeString(self):

--- a/dfdatetime/apfs_time.py
+++ b/dfdatetime/apfs_time.py
@@ -62,7 +62,7 @@ class APFSTime(posix_time.PosixTimeInNanoseconds):
       str: date and time value formatted as: "YYYY-MM-DD hh:mm:ss.#########" or
           None if the timestamp is missing or invalid.
     """
-    if (self._timestamp < self._INT64_MIN or
+    if (self._timestamp is None or self._timestamp < self._INT64_MIN or
         self._timestamp > self._INT64_MAX):
       return None
 

--- a/dfdatetime/posix_time.py
+++ b/dfdatetime/posix_time.py
@@ -201,3 +201,123 @@ class PosixTimeInMicroseconds(interface.DateTimeValues):
 
     return '{0:04d}-{1:02d}-{2:02d} {3:02d}:{4:02d}:{5:02d}.{6:06d}'.format(
         year, month, day_of_month, hours, minutes, seconds, microseconds)
+
+
+class PosixTimeInNanoseconds(interface.DateTimeValues):
+  """POSIX timestamp in nanoseconds.
+
+  Variant of the POSIX timestamp in nanoseconds.
+
+  Attributes:
+    is_local_time (bool): True if the date and time value is in local time.
+  """
+
+  _EPOCH = PosixTimeEpoch()
+
+  def __init__(self, timestamp=None):
+    """Initializes a POSIX timestamp in nanoseconds.
+
+    Args:
+      timestamp (Optional[int]): POSIX timestamp in nanoseconds.
+    """
+    super(PosixTimeInNanoseconds, self).__init__()
+    self._precision = definitions.PRECISION_1_NANOSECOND
+    self._timestamp = timestamp
+
+  @property
+  def timestamp(self):
+    """int: POSIX timestamp or None if timestamp is not set."""
+    return self._timestamp
+
+  def _GetNormalizedTimestamp(self):
+    """Retrieves the normalized timestamp.
+
+    Returns:
+      decimal.Decimal: normalized timestamp, which contains the number of
+          seconds since January 1, 1970 00:00:00 and a fraction of second used
+          for increased precision, or None if the normalized timestamp cannot be
+          determined.
+    """
+    if self._normalized_timestamp is None:
+      if self._timestamp is not None:
+        self._normalized_timestamp = (
+            decimal.Decimal(self._timestamp) /
+            definitions.NANOSECONDS_PER_SECOND)
+
+    return self._normalized_timestamp
+
+  def _CopyFromDateTimeString(self, time_string):
+    """Copies a POSIX timestamp from a date and time string.
+
+    Args:
+      time_string (str): date and time value formatted as:
+          YYYY-MM-DD hh:mm:ss.######[+-]##:##
+
+          Where # are numeric digits ranging from 0 to 9 and the seconds
+          fraction can be either 3 or 6 digits. The time of day, seconds
+          fraction and time zone offset are optional. The default time zone
+          is UTC.
+    """
+    date_time_values = self._CopyDateTimeFromString(time_string)
+
+    year = date_time_values.get('year', 0)
+    month = date_time_values.get('month', 0)
+    day_of_month = date_time_values.get('day_of_month', 0)
+    hours = date_time_values.get('hours', 0)
+    minutes = date_time_values.get('minutes', 0)
+    seconds = date_time_values.get('seconds', 0)
+    microseconds = date_time_values.get('microseconds', None)
+
+    timestamp = self._GetNumberOfSecondsFromElements(
+        year, month, day_of_month, hours, minutes, seconds)
+    timestamp *= definitions.NANOSECONDS_PER_SECOND
+
+    if microseconds:
+      nanoseconds = microseconds * definitions.MILLISECONDS_PER_SECOND
+      timestamp += nanoseconds
+
+    self._normalized_timestamp = None
+    self._timestamp = timestamp
+
+  def CopyFromDateTimeString(self, time_string):
+    """Copies a POSIX timestamp from a date and time string.
+
+    Args:
+      time_string (str): date and time value formatted as:
+          YYYY-MM-DD hh:mm:ss.######[+-]##:##
+
+          Where # are numeric digits ranging from 0 to 9 and the seconds
+          fraction can be either 3 or 6 digits. The time of day, seconds
+          fraction and time zone offset are optional. The default time zone
+          is UTC.
+    """
+    self._CopyFromDateTimeString(time_string)
+
+  def _CopyToDateTimeString(self):
+    """Copies the POSIX timestamp to a date and time string.
+
+    Returns:
+      str: date and time value formatted as: "YYYY-MM-DD hh:mm:ss.#########" or
+          None if the timestamp is missing or invalid.
+    """
+    if self._timestamp is None:
+      return None
+
+    timestamp, nanoseconds = divmod(
+        self._timestamp, definitions.NANOSECONDS_PER_SECOND)
+    number_of_days, hours, minutes, seconds = self._GetTimeValues(timestamp)
+
+    year, month, day_of_month = self._GetDateValuesWithEpoch(
+        number_of_days, self._EPOCH)
+
+    return '{0:04d}-{1:02d}-{2:02d} {3:02d}:{4:02d}:{5:02d}.{6:09d}'.format(
+        year, month, day_of_month, hours, minutes, seconds, nanoseconds)
+
+  def CopyToDateTimeString(self):
+    """Copies the POSIX timestamp to a date and time string.
+
+    Returns:
+      str: date and time value formatted as: "YYYY-MM-DD hh:mm:ss.#########" or
+          None if the timestamp is missing or invalid.
+    """
+    return self._CopyToDateTimeString()

--- a/tests/apfs_time.py
+++ b/tests/apfs_time.py
@@ -15,14 +15,6 @@ class APFSTimeTest(unittest.TestCase):
 
   # pylint: disable=protected-access
 
-  def testProperties(self):
-    """Tests the properties."""
-    apfs_time_object = apfs_time.APFSTime(timestamp=1281643591987654321)
-    self.assertEqual(apfs_time_object.timestamp, 1281643591987654321)
-
-    apfs_time_object = apfs_time.APFSTime()
-    self.assertIsNone(apfs_time_object.timestamp)
-
   def testGetNormalizedTimestamp(self):
     """Tests the _GetNormalizedTimestamp function."""
     apfs_time_object = apfs_time.APFSTime(timestamp=1281643591987654321)
@@ -36,80 +28,28 @@ class APFSTimeTest(unittest.TestCase):
     normalized_timestamp = apfs_time_object._GetNormalizedTimestamp()
     self.assertIsNone(normalized_timestamp)
 
+    apfs_time_object = apfs_time.APFSTime(timestamp=9223372036854775810)
+
+    date_time_string = apfs_time_object._GetNormalizedTimestamp()
+    self.assertIsNone(date_time_string)
+
   def testCopyFromDateTimeString(self):
     """Tests the CopyFromDateTimeString function."""
-    apfs_time_object = apfs_time.APFSTime()
-
-    expected_timestamp = 1281571200000000000
-    apfs_time_object.CopyFromDateTimeString('2010-08-12')
-    self.assertEqual(apfs_time_object.timestamp, expected_timestamp)
-
-    expected_timestamp = 1281647191000000000
-    apfs_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
-    self.assertEqual(apfs_time_object.timestamp, expected_timestamp)
-
-    expected_timestamp = 1281647191654321000
-    apfs_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.654321')
-    self.assertEqual(apfs_time_object.timestamp, expected_timestamp)
-
-    expected_timestamp = 1281650791654321000
-    apfs_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.654321-01:00')
-    self.assertEqual(apfs_time_object.timestamp, expected_timestamp)
-
-    expected_timestamp = 1281643591654321000
-    apfs_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.654321+01:00')
-    self.assertEqual(apfs_time_object.timestamp, expected_timestamp)
-
-    expected_timestamp = -11644387200000000000
-    apfs_time_object.CopyFromDateTimeString('1601-01-02 00:00:00')
-    self.assertEqual(apfs_time_object.timestamp, expected_timestamp)
-
     apfs_time_object = apfs_time.APFSTime()
     with self.assertRaises(ValueError):
       apfs_time_object.CopyFromDateTimeString('2554-07-21 23:34:34.000000')
 
   def testCopyToDateTimeString(self):
     """Tests the CopyToDateTimeString function."""
-    apfs_time_object = apfs_time.APFSTime(timestamp=1281643591987654321)
+    apfs_time_object = apfs_time.APFSTime(timestamp=9223372036854775810)
 
     date_time_string = apfs_time_object.CopyToDateTimeString()
-    self.assertEqual(date_time_string, '2010-08-12 20:06:31.987654321')
+    self.assertIsNone(date_time_string)
 
     apfs_time_object = apfs_time.APFSTime()
 
     date_time_string = apfs_time_object.CopyToDateTimeString()
     self.assertIsNone(date_time_string)
-
-  def testCopyToDateTimeStringISO8601(self):
-    """Tests the CopyToDateTimeStringISO8601 function."""
-    apfs_time_object = apfs_time.APFSTime(timestamp=1281643591987654321)
-
-    date_time_string = apfs_time_object.CopyToDateTimeStringISO8601()
-    self.assertEqual(date_time_string, '2010-08-12T20:06:31.987654321Z')
-
-  def testGetDate(self):
-    """Tests the GetDate function."""
-    apfs_time_object = apfs_time.APFSTime(timestamp=1281643591987654321)
-
-    date_tuple = apfs_time_object.GetDate()
-    self.assertEqual(date_tuple, (2010, 8, 12))
-
-    apfs_time_object = apfs_time.APFSTime()
-
-    date_tuple = apfs_time_object.GetDate()
-    self.assertEqual(date_tuple, (None, None, None))
-
-  def testGetTimeOfDay(self):
-    """Tests the GetTimeOfDay function."""
-    apfs_time_object = apfs_time.APFSTime(timestamp=1281643591987654321)
-
-    time_of_day_tuple = apfs_time_object.GetTimeOfDay()
-    self.assertEqual(time_of_day_tuple, (20, 6, 31))
-
-    apfs_time_object = apfs_time.APFSTime()
-
-    time_of_day_tuple = apfs_time_object.GetTimeOfDay()
-    self.assertEqual(time_of_day_tuple, (None, None, None))
 
 
 if __name__ == '__main__':

--- a/tests/posix_time.py
+++ b/tests/posix_time.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import decimal
 import unittest
 
 from dfdatetime import posix_time
@@ -242,6 +243,112 @@ class PosixTimeInMicrosecondsTest(unittest.TestCase):
     self.assertEqual(time_of_day_tuple, (20, 6, 31))
 
     posix_time_object = posix_time.PosixTimeInMicroseconds()
+
+    time_of_day_tuple = posix_time_object.GetTimeOfDay()
+    self.assertEqual(time_of_day_tuple, (None, None, None))
+
+
+class PosixTimeInNanoSecondsTest(unittest.TestCase):
+  """Tests for the POSIX timestamp in nanoseconds."""
+
+  # pylint: disable=protected-access
+
+  def testProperties(self):
+    """Tests the properties."""
+    posix_time_object = posix_time.PosixTimeInNanoseconds(
+        timestamp=1281643591987654321)
+    self.assertEqual(posix_time_object.timestamp, 1281643591987654321)
+
+    posix_time_object = posix_time.PosixTimeInNanoseconds()
+    self.assertIsNone(posix_time_object.timestamp)
+
+  def testGetNormalizedTimestamp(self):
+    """Tests the _GetNormalizedTimestamp function."""
+    posix_time_object = posix_time.PosixTimeInNanoseconds(
+        timestamp=1281643591987654321)
+
+    normalized_timestamp = posix_time_object._GetNormalizedTimestamp()
+    self.assertEqual(
+        normalized_timestamp, decimal.Decimal('1281643591.987654321'))
+
+    posix_time_object = posix_time.PosixTimeInNanoseconds()
+
+    normalized_timestamp = posix_time_object._GetNormalizedTimestamp()
+    self.assertIsNone(normalized_timestamp)
+
+  def testCopyFromDateTimeString(self):
+    """Tests the CopyFromDateTimeString function."""
+    posix_time_object = posix_time.PosixTimeInNanoseconds()
+
+    expected_timestamp = 1281571200000000000
+    posix_time_object.CopyFromDateTimeString('2010-08-12')
+    self.assertEqual(posix_time_object.timestamp, expected_timestamp)
+
+    expected_timestamp = 1281647191000000000
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31')
+    self.assertEqual(posix_time_object.timestamp, expected_timestamp)
+
+    expected_timestamp = 1281647191654321000
+    posix_time_object.CopyFromDateTimeString('2010-08-12 21:06:31.654321')
+    self.assertEqual(posix_time_object.timestamp, expected_timestamp)
+
+    expected_timestamp = 1281650791654321000
+    posix_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.654321-01:00')
+    self.assertEqual(posix_time_object.timestamp, expected_timestamp)
+
+    expected_timestamp = 1281643591654321000
+    posix_time_object.CopyFromDateTimeString(
+        '2010-08-12 21:06:31.654321+01:00')
+    self.assertEqual(posix_time_object.timestamp, expected_timestamp)
+
+    expected_timestamp = -11644387200000000000
+    posix_time_object.CopyFromDateTimeString('1601-01-02 00:00:00')
+    self.assertEqual(posix_time_object.timestamp, expected_timestamp)
+
+  def testCopyToDateTimeString(self):
+    """Tests the CopyToDateTimeString function."""
+    posix_time_object = posix_time.PosixTimeInNanoseconds(
+        timestamp=1281643591987654321)
+
+    date_time_string = posix_time_object.CopyToDateTimeString()
+    self.assertEqual(date_time_string, '2010-08-12 20:06:31.987654321')
+
+    posix_time_object = posix_time.PosixTimeInNanoseconds()
+
+    date_time_string = posix_time_object.CopyToDateTimeString()
+    self.assertIsNone(date_time_string)
+
+  def testCopyToDateTimeStringISO8601(self):
+    """Tests the CopyToDateTimeStringISO8601 function."""
+    posix_time_object = posix_time.PosixTimeInNanoseconds(
+        timestamp=1281643591987654321)
+
+    date_time_string = posix_time_object.CopyToDateTimeStringISO8601()
+    self.assertEqual(date_time_string, '2010-08-12T20:06:31.987654321Z')
+
+  def testGetDate(self):
+    """Tests the GetDate function."""
+    posix_time_object = posix_time.PosixTimeInNanoseconds(
+        timestamp=1281643591987654321)
+
+    date_tuple = posix_time_object.GetDate()
+    self.assertEqual(date_tuple, (2010, 8, 12))
+
+    posix_time_object = posix_time.PosixTimeInNanoseconds()
+
+    date_tuple = posix_time_object.GetDate()
+    self.assertEqual(date_tuple, (None, None, None))
+
+  def testGetTimeOfDay(self):
+    """Tests the GetTimeOfDay function."""
+    posix_time_object = posix_time.PosixTimeInNanoseconds(
+        timestamp=1281643591987654321)
+
+    time_of_day_tuple = posix_time_object.GetTimeOfDay()
+    self.assertEqual(time_of_day_tuple, (20, 6, 31))
+
+    posix_time_object = posix_time.PosixTimeInNanoseconds()
 
     time_of_day_tuple = posix_time_object.GetTimeOfDay()
     self.assertEqual(time_of_day_tuple, (None, None, None))


### PR DESCRIPTION
Part of #116. As suggested in PR #119 I moved integer boundaries checks to APFSTime()