### PR TITLE
Changed interface._GetDateValues to correctly handle end of year

### DIFF
--- a/config/dpkg/changelog
+++ b/config/dpkg/changelog
@@ -1,5 +1,5 @@
-dfdatetime (20181214-1) unstable; urgency=low
+dfdatetime (20190116-1) unstable; urgency=low
 
   * Auto-generated
 
- -- Log2Timeline maintainers <log2timeline-maintainers@googlegroups.com>  Fri, 14 Dec 2018 08:10:05 +0100
+ -- Log2Timeline maintainers <log2timeline-maintainers@googlegroups.com>  Wed, 16 Jan 2019 20:40:11 +0100

--- a/dfdatetime/__init__.py
+++ b/dfdatetime/__init__.py
@@ -5,4 +5,4 @@ dfDateTime, or Digital Forensics date and time, provides date and time
 objects to preserve accuracy and precision.
 """
 
-__version__ = '20181214'
+__version__ = '20190116'

--- a/dfdatetime/interface.py
+++ b/dfdatetime/interface.py
@@ -620,6 +620,11 @@ class DateTimeValues(object):
       days_per_month = self._GetDaysPerMonth(year, month)
       number_of_days = days_per_month - number_of_days
 
+    elif number_of_days == 0:
+      number_of_days = 31
+      month = 12
+      year -= 1
+
     return year, month, number_of_days
 
   def _GetDateValuesWithEpoch(self, number_of_days, date_time_epoch):

--- a/tests/interface.py
+++ b/tests/interface.py
@@ -433,6 +433,27 @@ class DateTimeValuesTest(unittest.TestCase):
     self.assertEqual(month, 12)
     self.assertEqual(day_of_month, 28)
 
+    year, month, day_of_month = date_time_values._GetDateValues(0, 1970, 1, 1)
+    self.assertEqual(year, 1970)
+    self.assertEqual(month, 1)
+    self.assertEqual(day_of_month, 1)
+
+    year, month, day_of_month = date_time_values._GetDateValues(-1, 1970, 1, 1)
+    self.assertEqual(year, 1969)
+    self.assertEqual(month, 12)
+    self.assertEqual(day_of_month, 31)
+
+    year, month, day_of_month = date_time_values._GetDateValues(364, 1970, 1, 1)
+    self.assertEqual(year, 1970)
+    self.assertEqual(month, 12)
+    self.assertEqual(day_of_month, 31)
+
+    year, month, day_of_month = date_time_values._GetDateValues(
+        1460, 1970, 1, 1)
+    self.assertEqual(year, 1973)
+    self.assertEqual(month, 12)
+    self.assertEqual(day_of_month, 31)
+
   def testGetDateValuesWithEpoch(self):
     """Tests the _GetDateValuesWithEpoch function."""
     date_time_epoch = interface.DateTimeEpoch(2000, 1, 1)


### PR DESCRIPTION
Changed interface._GetDateValues to correctly handle end of year