### PR TITLE
fixed NewFromDeltaAndYear to respect leap years

### DIFF
--- a/dfdatetime/time_elements.py
+++ b/dfdatetime/time_elements.py
@@ -861,6 +861,11 @@ class TimeElements(interface.DateTimeValues):
     delta_year, month, day_of_month, hours, minutes, seconds = (
         self._time_elements_tuple)
 
+    if (month == 2 and day_of_month == 29):
+        while (not ((year+delta_year)%4 == 0 and (year+delta_year)%100 != 0 or \
+                (year+delta_year)%400 == 0)):
+            year -= 1
+
     time_elements_tuple = (
         year + delta_year, month, day_of_month, hours, minutes, seconds)
 


### PR DESCRIPTION
Running

```
$ cat syslog 
Feb 29 00:00:01 hostname dhcpd[12345]: DHCPREQUEST for 1.1.1.1 from af:fe:af:fe:af:fe via eth0
$ log2timeline.py syslog
```
returns
```
dfdatetime/interface.py", line 828, in _GetNumberOfSecondsFromElements
    raise ValueError(f'Day of month value: {day_of_month:d} out of bounds.')
```
.

This patch adds a leap year test to NewFromDeltaAndYear. If it fails, it chooses the most recent leap year.